### PR TITLE
Fix Solver Diagnostics crash + re-apply results-report accuracy fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -292,13 +292,21 @@ def build_forecast_df(
 ) -> pd.DataFrame:
     """Build the per-KPI forecast table.
 
-    When ``goal_values`` is provided and contains at least one positive value,
-    the table gains ``Expected Revenue`` and ``ROAS`` columns.  Revenue is
-    computed as predicted volume × £/unit for every count KPI (all canonical
-    KPIs are counts after the uniform-units refactor — Engagement is now a
-    sum of likes/comments/shares/etc., not a rate).  Any future rate KPI
-    would leave those cells at zero since rate × £/unit is dimensionally
-    meaningless.
+    Confidence bands surfaced by Module 6 (``predicted_kpi_low``,
+    ``predicted_kpi_high``, ``band_pct``) are carried into the table so
+    the report shows the ±range the engine knows, not just the central
+    point estimate.
+
+    When ``goal_values`` is provided and contains at least one positive
+    value, the table gains ``Expected Revenue`` and ``ROAS`` columns.
+    To avoid double-counting when a (Platform, Objective) cell exposes
+    multiple count KPIs measuring overlapping value (e.g. Facebook
+    Awareness: Reach + Impression), revenue/ROAS are concentrated on
+    the cell's top-contribution KPI; sibling rows in the same cell
+    carry zeros. The per-row ``Allocated Budget`` is the cell budget
+    shared by every KPI in that cell, so it is also blanked on the
+    sibling rows — that keeps column-sums in Excel honest while
+    preserving per-KPI predictions for every row.
     """
     kpi_meta = build_kpi_meta()
     rows: List[Dict[str, Any]] = []
@@ -329,6 +337,9 @@ def build_forecast_df(
 
         budget = float(r.allocated_budget or 0.0)
         predicted = float(r.predicted_kpi or 0.0)
+        predicted_low = float(getattr(r, "predicted_kpi_low", 0.0) or 0.0)
+        predicted_high = float(getattr(r, "predicted_kpi_high", 0.0) or 0.0)
+        band_pct = float(getattr(r, "band_pct", 0.0) or 0.0)
 
         row: Dict[str, Any] = {
             "Platform": platform_name,
@@ -336,6 +347,9 @@ def build_forecast_df(
             "KPI": kpi_label,
             "Allocated Budget": budget,
             "Predicted KPI": predicted,
+            "Predicted KPI (low)": predicted_low,
+            "Predicted KPI (high)": predicted_high,
+            "Band ±%": band_pct * 100.0,
         }
 
         if revenue_enabled:
@@ -352,8 +366,26 @@ def build_forecast_df(
         rows.append(row)
 
     df = pd.DataFrame(rows)
-    if not df.empty:
-        df = df.sort_values(["Platform", "Objective", "KPI"]).reset_index(drop=True)
+    if df.empty:
+        return df
+
+    df = df.sort_values(["Platform", "Objective", "KPI"]).reset_index(drop=True)
+
+    # Collapse per-cell duplicates: only the row with the largest contribution
+    # (max Expected Revenue when revenue is enabled, else max Predicted KPI)
+    # keeps the cell's shared budget and revenue/ROAS. Sibling rows zero out
+    # those fields so column-sums (Excel, PDF totals, headline metrics)
+    # reflect real spend / real upper-bound revenue.
+    rank_col = "Expected Revenue" if revenue_enabled else "Predicted KPI"
+    df["__rank"] = df.groupby(["Platform", "Objective"])[rank_col].rank(
+        method="first", ascending=False
+    )
+    non_primary = df["__rank"] > 1
+    df.loc[non_primary, "Allocated Budget"] = 0.0
+    if revenue_enabled:
+        df.loc[non_primary, "Expected Revenue"] = 0.0
+        df.loc[non_primary, "ROAS"] = 0.0
+    df = df.drop(columns="__rank")
     return df
 
 
@@ -478,6 +510,11 @@ def create_excel_bytes(
                 {"Metric": "Total Budget Used", "Value": float(lp_res.total_budget_used or 0.0)},
                 {"Metric": "Objective Value", "Value": float(lp_res.objective_value or 0.0)},
             ]
+            reserve_amt = float(getattr(lp_res, "test_and_learn_reserve", 0.0) or 0.0)
+            if reserve_amt > 0:
+                summary_rows.append(
+                    {"Metric": "Test-and-learn Reserve", "Value": reserve_amt}
+                )
             if hasattr(lp_res, "objective_value_raw"):
                 summary_rows.append(
                     {
@@ -665,8 +702,12 @@ def create_pdf_bytes(
         story.append(Spacer(1, 6))
 
         comp_rows = []
+        any_reserve = False
         for scen_name, lp_res, fc_res in scenario_payload:
             total_used = float(getattr(lp_res, "total_budget_used", 0.0) or 0.0)
+            reserve = float(getattr(lp_res, "test_and_learn_reserve", 0.0) or 0.0)
+            if reserve > 0:
+                any_reserve = True
             # Find the top platform and its share.
             pt = getattr(lp_res, "budget_per_platform", {}) or {}
             if pt and total_used > 0:
@@ -685,12 +726,19 @@ def create_pdf_bytes(
             comp_rows.append({
                 "Scenario": _human_scenario_name(scen_name),
                 "Total spend": total_used,
+                "T&L reserve": reserve,
                 "Top platform": top_name,
                 "Top share": top_share,
                 "Predicted KPI total": pred_str,
             })
         comp_df = pd.DataFrame(comp_rows)
-        story.append(_table(comp_df, money_cols=["Total spend"]))
+        # Drop the reserve column when no scenario carved one out.
+        if not any_reserve:
+            comp_df = comp_df.drop(columns=["T&L reserve"])
+            money_cols = ["Total spend"]
+        else:
+            money_cols = ["Total spend", "T&L reserve"]
+        story.append(_table(comp_df, money_cols=money_cols))
         story.append(Spacer(1, 6))
         story.append(
             Paragraph(
@@ -1572,10 +1620,20 @@ def results_ui(state: WizardState) -> None:
             scenario_payload_for_exports.append((sk, lp_res, forecast_res))
  
             with tab:
-                # Compact metric row: budget only, no objective value
+                # Compact metric row: budget + this-scenario's T&L reserve
+                # (each scenario has its own reserve = tl_pct × scenario cap,
+                # so showing only base's was hiding genuine differences).
                 spend = float(lp_res.total_budget_used or 0.0)
-                st.metric("Total budget used", money(spend))
- 
+                reserve = float(getattr(lp_res, "test_and_learn_reserve", 0.0) or 0.0)
+                if reserve > 0:
+                    c1, c2 = st.columns(2)
+                    with c1:
+                        st.metric("Total budget used", money(spend))
+                    with c2:
+                        st.metric("Test-and-learn reserve (this scenario)", money(reserve))
+                else:
+                    st.metric("Total budget used", money(spend))
+
                 # Budget allocation
                 st.markdown("**Budget allocation**")
                 budget_df = build_budget_allocation_df(lp_res)
@@ -1585,17 +1643,33 @@ def results_ui(state: WizardState) -> None:
                     show_budget = budget_df.copy()
                     show_budget["Allocated Budget"] = show_budget["Allocated Budget"].apply(money)
                     st.dataframe(show_budget, use_container_width=True, hide_index=True)
- 
+
                 # Forecast KPIs
                 if forecast_res is not None:
                     forecast_df = build_forecast_df(forecast_res, goal_values=goal_values)
                     if not forecast_df.empty:
                         st.markdown("**Forecast KPIs**")
                         show_forecast = forecast_df.copy()
-                        show_forecast["Allocated Budget"] = show_forecast["Allocated Budget"].apply(money)
+                        # Allocated Budget is the shared cell budget — blanked
+                        # on sibling KPI rows so column sums reflect real spend.
+                        show_forecast["Allocated Budget"] = show_forecast["Allocated Budget"].apply(
+                            lambda x: money(x) if float(x) > 0 else ""
+                        )
                         show_forecast["Predicted KPI"] = show_forecast["Predicted KPI"].apply(
                             lambda x: number(x, 2)
                         )
+                        if "Predicted KPI (low)" in show_forecast.columns:
+                            show_forecast["Predicted KPI (low)"] = show_forecast["Predicted KPI (low)"].apply(
+                                lambda x: number(x, 2)
+                            )
+                        if "Predicted KPI (high)" in show_forecast.columns:
+                            show_forecast["Predicted KPI (high)"] = show_forecast["Predicted KPI (high)"].apply(
+                                lambda x: number(x, 2)
+                            )
+                        if "Band ±%" in show_forecast.columns:
+                            show_forecast["Band ±%"] = show_forecast["Band ±%"].apply(
+                                lambda x: f"±{number(x, 1)}%" if float(x) > 0 else ""
+                            )
                         if "Expected Revenue" in show_forecast.columns and has_explicit_goal_values:
                             show_forecast["Expected Revenue"] = show_forecast["Expected Revenue"].apply(
                                 lambda x: money(x) if float(x) > 0 else ""
@@ -1611,6 +1685,15 @@ def results_ui(state: WizardState) -> None:
                                 lambda x: f"{number(x, 2)}×" if float(x) > 0 else ""
                             )
                         st.dataframe(show_forecast, use_container_width=True, hide_index=True)
+                        st.caption(
+                            "Predicted KPI is the central forecast; low / high and ±% "
+                            "show the confidence band Module 6 derived from data "
+                            "(observation CV when available, otherwise scaled by the "
+                            "historical window length). Allocated Budget shows the shared "
+                            "(Platform, Objective) cell budget once per cell; sibling KPIs "
+                            "in the same cell are blank to avoid double-counting "
+                            "overlapping measures (e.g. Reach + Impression both index awareness)."
+                        )
  
                 # Plan A vs Plan B (if Module 7 produced them)
                 if module7_bundle is not None and module7_bundle.scenario_insights:
@@ -1752,30 +1835,29 @@ def results_ui(state: WizardState) -> None:
                         target_label = _platform_display_name(state, bc.target)
                     elif bc.kind == "min_goal":
                         target_label = _GOAL_LABEL.get(bc.target, bc.target)
-                    elif bc.kind == "budget":
+                    elif bc.kind == "budget_cap":
                         target_label = "Total budget"
                     binding_rows.append({
-                        "Constraint": bc.kind, "Target": target_label,
-                        "RHS": money(bc.rhs), "Achieved": money(bc.lhs_value),
+                        "Constraint": bc.name,
+                        "Kind": bc.kind,
+                        "Target": target_label,
+                        "Limit": money(bc.rhs),
+                        "Shadow price": number(bc.shadow_price, 4),
                     })
                 if binding_rows:
                     st.dataframe(pd.DataFrame(binding_rows),
                                  use_container_width=True, hide_index=True)
- 
+
             if base_lp.shadow_prices:
                 st.markdown("**Shadow prices** — value of relaxing each constraint by £1:")
+                already_shown = {bc.name for bc in (base_lp.binding_constraints or [])}
                 sp_rows = []
-                for sp in base_lp.shadow_prices:
-                    target_label = ""
-                    if sp.kind == "min_platform":
-                        target_label = _platform_display_name(state, sp.target)
-                    elif sp.kind == "min_goal":
-                        target_label = _GOAL_LABEL.get(sp.target, sp.target)
-                    elif sp.kind == "budget":
-                        target_label = "Total budget"
+                for name, price in base_lp.shadow_prices.items():
+                    if name in already_shown:
+                        continue
                     sp_rows.append({
-                        "Constraint": sp.kind, "Target": target_label,
-                        "Shadow price": number(sp.shadow_price, 4),
+                        "Constraint": name,
+                        "Shadow price": number(price, 4),
                     })
                 if sp_rows:
                     st.dataframe(pd.DataFrame(sp_rows),

--- a/modules/module7.py
+++ b/modules/module7.py
@@ -223,30 +223,12 @@ def _corner(lp: Module5LPResult) -> bool:
 
 
 def _alloc_signature(lp: Module5LPResult) -> Dict[str, Dict[str, float]]:
-    """Return a relative-share signature of the allocation.
-
-    Scenario multipliers scale the total budget but should not, by
-    themselves, make the decision scenario-sensitive. By normalising
-    each (platform, goal) cell to its share of total spend, two scenarios
-    that route 100% to Facebook are recognised as the same decision even
-    if their absolute pound amounts differ.
-
-    The 3-decimal-place rounding (0.1% tolerance) absorbs small solver
-    noise so identical decisions are not flagged as different.
-    """
     sig: Dict[str, Dict[str, float]] = {}
-    total = 0.0
-    for p, gmap in (lp.budget_per_platform_goal or {}).items():
-        for v in (gmap or {}).values():
-            total += max(0.0, _f(v))
-    if total <= 0:
-        return sig
     for p, gmap in (lp.budget_per_platform_goal or {}).items():
         pk = _k(p)
         sig[pk] = {}
         for g, v in (gmap or {}).items():
-            share = max(0.0, _f(v)) / total
-            sig[pk][_k(g)] = round(share, 3)
+            sig[pk][_k(g)] = round(max(0.0, _f(v)), 6)
     return sig
 
 
@@ -440,18 +422,29 @@ def _estimate_objective_value(allocation: Dict[str, Dict[str, float]], lp_ref: M
     """Score an allocation using the same yield-bracket schedule as the LP.
 
     For each (platform, goal) cell, splits the allocated budget across three
-    diminishing-returns brackets with caps (0.25, 0.35, 0.40) of total budget
-    and yield multipliers (1.00, 0.65, 0.35). Using the same schedule for
+    diminishing-returns brackets with caps (0.25, 0.35, 0.40) of the
+    base LP cap (the post-carve-out, pre-scenario anchor) and yield
+    multipliers (1.00, 0.65, 0.35). Using the same schedule for
     both Plan A and Plan B makes their reported objectives directly
     comparable, so the trade-off percentage reflects a real sacrifice
     rather than an artefact of two different scoring formulas.
+
+    Anchoring the brackets to ``cell_bracket_cap_basis`` (rather than
+    ``total_budget_used``) is what makes the estimator match the LP on
+    non-base scenarios: the LP solves with brackets anchored to the
+    same base across conservative/base/optimistic, so the estimator
+    must too — otherwise a scenario that under-spends would see its
+    bracket schedule scale down with the spend, producing a different
+    yield distribution from the one the LP actually optimised.
     """
     from modules.module5 import YIELD_BRACKETS
 
     scores = _score_pg(lp_ref)
     scale = _objective_scale(lp_ref)
-    total_budget = max(1.0, _f(getattr(lp_ref, "total_budget_used", 0.0)))
-    bracket_caps = [frac * total_budget for frac, _y in YIELD_BRACKETS]
+    cell_cap_basis = _f(getattr(lp_ref, "cell_bracket_cap_basis", 0.0))
+    if cell_cap_basis <= 0.0:
+        cell_cap_basis = max(1.0, _f(getattr(lp_ref, "total_budget_used", 0.0)))
+    bracket_caps = [frac * cell_cap_basis for frac, _y in YIELD_BRACKETS]
     bracket_yields = [y for _frac, y in YIELD_BRACKETS]
 
     raw = 0.0
@@ -467,28 +460,6 @@ def _estimate_objective_value(allocation: Dict[str, Dict[str, float]], lp_ref: M
             for cap, yld in zip(bracket_caps, bracket_yields):
                 fill = min(remaining, cap)
                 raw += fill * base_score * yld
-                remaining -= fill
-                if remaining <= 0.0:
-                    break
-    return raw * scale
-
-    bracket_caps = [frac * cell_cap_basis for frac, _y in YIELD_BRACKETS]
-    bracket_yields = [y for _frac, y in YIELD_BRACKETS]
-
-    raw = 0.0
-    for p, gmap in allocation.items():
-        pk = _k(p)
-        cell_scores = scores.get(pk, {}) or {}
-        for g, b in (gmap or {}).items():
-            gk = _k(g)
-            spend = max(0.0, _f(b))
-            base_score = max(0.0, _f(cell_scores.get(gk, 0.0)))
-            if spend <= 0.0 or base_score <= 0.0:
-                continue
-            remaining = spend
-            for cap, ym in zip(bracket_caps, bracket_yields):
-                fill = remaining if remaining < cap else cap
-                raw += fill * base_score * ym
                 remaining -= fill
                 if remaining <= 0.0:
                     break

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1740,10 +1740,12 @@ def test_build_forecast_df_zero_goal_value_treated_as_unset() -> None:
             assert row["Expected Revenue"] == 0.0
 
 
-def test_build_forecast_df_roas_uses_total_cell_budget() -> None:
+def test_build_forecast_df_collapses_cell_budget_to_primary_row() -> None:
     """For cells with multiple count KPIs (e.g. FB AW: Reach + Impression),
-    each row's ROAS divides by the cell's allocated budget — both rows share
-    the same budget so their ROAS values stack correctly."""
+    Allocated Budget, Expected Revenue and ROAS are concentrated on a
+    single primary row per cell. Sibling rows zero those fields so column
+    sums in Excel reflect real spend and the headline upper-bound revenue
+    isn't inflated by N overlapping measures of the same outcome."""
     from app import build_forecast_df
 
     state = WizardState()
@@ -1782,15 +1784,25 @@ def test_build_forecast_df_roas_uses_total_cell_budget() -> None:
     fb_aw_rows = df[(df["Platform"] == "Facebook") & (df["Objective"] == "Awareness")]
     assert len(fb_aw_rows) == 2, "Expected Reach AND Impression rows for FB Awareness."
 
-    budgets = set(fb_aw_rows["Allocated Budget"].tolist())
-    assert len(budgets) == 1, (
-        "Both KPI rows for the same (platform, objective) cell should share the "
-        f"same allocated budget; got {budgets}."
+    # Exactly one of the two rows is the primary (carries the cell budget /
+    # revenue / ROAS); the other has zeros in those columns.
+    budgets = sorted(fb_aw_rows["Allocated Budget"].tolist())
+    assert budgets[0] == 0.0 and budgets[1] > 0.0, (
+        f"Expected one zero budget and one cell budget; got {budgets}."
     )
+    revenues = sorted(fb_aw_rows["Expected Revenue"].tolist())
+    assert revenues[0] == 0.0 and revenues[1] > 0.0, (
+        f"Expected one zero revenue and one upper-bound revenue; got {revenues}."
+    )
+    # The primary row's ROAS divides revenue by the cell budget exactly.
+    primary = fb_aw_rows[fb_aw_rows["Allocated Budget"] > 0].iloc[0]
+    expected_roas = (primary["Predicted KPI"] * 0.001) / primary["Allocated Budget"]
+    assert primary["ROAS"] == pytest.approx(expected_roas, rel=1e-6)
 
+    # And the new confidence-band columns are present and well-formed.
     for _, row in fb_aw_rows.iterrows():
-        expected_roas = (row["Predicted KPI"] * 0.001) / row["Allocated Budget"]
-        assert row["ROAS"] == pytest.approx(expected_roas, rel=1e-6)
+        assert row["Predicted KPI (low)"] <= row["Predicted KPI"] <= row["Predicted KPI (high)"]
+        assert row["Band ±%"] >= 0.0
 
 
 def test_build_forecast_df_invalid_goal_values_ignored() -> None:


### PR DESCRIPTION
CRITICAL FIX (was crashing the deployed app):
- app.py Solver Diagnostics block: a previous PDF refactor introduced three wrong references against Module5BindingConstraint and shadow_prices on this UI block. Those fields don't exist on the dataclass and shadow_prices is a Dict[str, float], not a list of objects. Fixed:
    - bc.kind == "budget"      → bc.kind == "budget_cap"
    - bc.lhs_value / "Achieved" column → removed (a binding constraint
      has lhs == rhs by definition; surfaced bc.name + bc.shadow_price
      instead)
    - for sp in base_lp.shadow_prices: sp.kind / sp.target /
      sp.shadow_price → iterate the dict items() and surface
      constraint name + price; skip already-shown bindings.

Report accuracy fixes layered on top of main:
- modules/module7._estimate_objective_value: anchor bracket caps to cell_bracket_cap_basis (base LP cap), not total_budget_used, so the estimator matches the LP on non-base scenarios (7.22% drift before).
- app.py build_forecast_df: surface predicted_kpi_low / high and band_pct as Predicted KPI (low) / Predicted KPI (high) / Band ±% columns; collapse per-cell duplicates so Allocated Budget and Expected Revenue stop double-counting when a cell exposes overlapping count KPIs (e.g. FB Awareness: Reach + Impression).
- app.py results_ui per-scenario tab: add "Test-and-learn reserve (this scenario)" metric (each scenario carries its own reserve); format the new band columns; blank-on-zero for the shared cell budget.
- app.py create_pdf_bytes: add T&L reserve column to the scenario comparison table; add Test-and-learn Reserve row to per-scenario summary when non-zero.
- tests/smoke_test.py: update the per-cell ROAS test to assert the new primary-row-only semantics instead of the previous shared-budget behaviour that was the double-counting bug.