### PR TITLE
Add stability_score property to Module5MonteCarloResult

### DIFF
--- a/modules/module5.py
+++ b/modules/module5.py
@@ -1283,6 +1283,18 @@ class Module5MonteCarloResult:
     # Surfaced so the user can see *which* assumptions had the most noise.
     cell_sigma: Dict[str, Dict[str, float]] = field(default_factory=dict)
 
+    @property
+    def stability_score(self) -> float:
+        """Plan-level stability in [0, 1]: 1 − mean platform CV across
+        materially-funded platforms (those with mean allocation > £1).
+        Higher means platform ranks are less sensitive to productivity noise.
+        """
+        cvs = [s.cv for s in self.per_platform if s.mean > 1.0]
+        if not cvs:
+            return 1.0
+        mean_cv = sum(cvs) / len(cvs)
+        return max(0.0, min(1.0, 1.0 - mean_cv))
+
 
 def _per_cell_sigma(state: WizardState) -> Dict[str, Dict[str, float]]:
     """Best estimate of per-(platform, goal) productivity noise.


### PR DESCRIPTION
## Summary
Added a new `stability_score` property to the `Module5MonteCarloResult` class that quantifies plan-level stability based on platform allocation sensitivity to productivity noise.

## Key Changes
- **New property `stability_score`**: Computes a normalized stability metric in the range [0, 1] where:
  - 1.0 indicates maximum stability (platform ranks are insensitive to productivity noise)
  - 0.0 indicates minimum stability (high sensitivity to noise)
  - Calculation: `1 − mean(coefficient of variation)` across materially-funded platforms
  - Only considers platforms with mean allocation > £1 to focus on meaningful allocations
  - Returns 1.0 if no materially-funded platforms exist (edge case handling)

## Implementation Details
- Uses existing `per_platform` data and coefficient of variation (`cv`) from platform statistics
- Clamps result to [0, 1] range using `max(0.0, min(1.0, ...))` to handle edge cases
- Includes comprehensive docstring explaining the metric's meaning and interpretation

https://claude.ai/code/session_01UG8EDPz9tu4Mxq7CxiKBmo