### PR TITLE
Rename project to CLARO for publication

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
-title: "Marketing Budget Optimisation and Decision Support Framework"
+title: "CLARO: Constrained Linear Allocation and Resource Optimiser — a Decision-Support Framework for Marketing Budget Allocation"
 abstract: "An open source decision support pipeline for constrained marketing budget allocation across digital platforms and competing business objectives. Integrates Linear Programming optimisation, policy constraints, multi-scenario evaluation, goal-aligned KPI forecasting, and a rule-based decision interpretation layer."
 authors:
   - family-names: "Rezvanjoo"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Marketing Budget Optimisation and Decision Support Framework
+# CLARO — Constrained Linear Allocation and Resource Optimiser
+
+*A decision-support framework for marketing budget allocation.*
 
 ## Overview
 
@@ -282,7 +284,7 @@ This project demonstrates applied expertise in:
 
 If you use this software in academic work, please cite it using the metadata in `CITATION.cff`, or as follows:
 
-> Rezvanjoo, H. (2026). *Marketing Budget Optimisation and Decision Support Framework* (Version 0.2.0). https://github.com/Hoda834/digital-budget-optimisation-engine
+> Rezvanjoo, H. (2026). *CLARO: Constrained Linear Allocation and Resource Optimiser — a Decision-Support Framework for Marketing Budget Allocation* (Version 0.2.0). https://github.com/Hoda834/digital-budget-optimisation-engine
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -2282,7 +2282,7 @@ def module2_ui(state: WizardState) -> None:
 
 
 def main() -> None:
-    st.set_page_config(page_title="Marketing Budget Optimisation", layout="wide")
+    st.set_page_config(page_title="CLARO — Marketing Budget Optimisation", layout="wide")
     initialise_state()
 
     state: WizardState = st.session_state["wizard_state"]


### PR DESCRIPTION
Set the citable name to 'CLARO: Constrained Linear Allocation and Resource Optimiser' across the citation metadata, README heading and citation example, and the Streamlit page title. Done before the v0.2.0 tag so the DOI carries the final name.