### PR TITLE
Release prep v0.2.0: rename to CLARO, doc fixes, terminology disambiguation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
-title: "Marketing Budget Optimisation and Decision Support Framework"
+title: "CLARO: Constrained Linear Allocation and Resource Optimiser — a Decision-Support Framework for Marketing Budget Allocation"
 abstract: "An open source decision support pipeline for constrained marketing budget allocation across digital platforms and competing business objectives. Integrates Linear Programming optimisation, policy constraints, multi-scenario evaluation, goal-aligned KPI forecasting, and a rule-based decision interpretation layer."
 authors:
   - family-names: "Rezvanjoo"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Marketing Budget Optimisation and Decision Support Framework
+# CLARO — Constrained Linear Allocation and Resource Optimiser
+
+*A decision-support framework for marketing budget allocation.*
 
 ## Overview
 
@@ -282,7 +284,7 @@ This project demonstrates applied expertise in:
 
 If you use this software in academic work, please cite it using the metadata in `CITATION.cff`, or as follows:
 
-> Rezvanjoo, H. (2026). *Marketing Budget Optimisation and Decision Support Framework* (Version 0.2.0). https://github.com/Hoda834/digital-budget-optimisation-engine
+> Rezvanjoo, H. (2026). *CLARO: Constrained Linear Allocation and Resource Optimiser — a Decision-Support Framework for Marketing Budget Allocation* (Version 0.2.0). https://github.com/Hoda834/digital-budget-optimisation-engine
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The composition is auditable — every parsed CSV returns a breakdown showing pe
 
 ### 5. Forecasting Layer with Honest Uncertainty
 
-Module 6 produces per-KPI forecasts from the LP allocation. Confidence bands are **data-driven**:
+Module 6 produces per-KPI forecasts from the LP allocation. Uncertainty bands are **data-driven** (and are deliberately *not* called "confidence" — that word is reserved for Module 7's decision confidence score, a separate concept):
 
 * If Module 3 has ≥3 historical observations per KPI, the band is the sample coefficient of variation — true noise from data.
 * Otherwise, the band scales by `√(30 / historical_days)` — a 90-day history produces a ~17% band, a 7-day history ~62%.
@@ -226,7 +226,7 @@ The same command runs automatically on every push and pull request via GitHub Ac
 │   ├── module3.py               # Historical KPIs (manual or via CSV)
 │   ├── module4.py               # Cost-per-unit + outlier sweep
 │   ├── module5.py               # LP with shrinkage, Monte Carlo, diagnostics
-│   ├── module6.py               # Forecasts with data-driven confidence bands
+│   ├── module6.py               # Forecasts with data-driven uncertainty bands
 │   └── module7.py               # Insights + Module7Policy
 ├── docs/                        # Design + modelling documentation
 ├── tests/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Instead of looking at channels separately, the system treats marketing as a cons
 
 The framework is designed to help managers make better decisions, not just to automate processes.
 
-https://github.com/Hoda834/digital-budget-optimisation-engine.wiki.git
+📖 Project wiki: https://github.com/Hoda834/digital-budget-optimisation-engine/wiki
 
 ---
 
@@ -203,7 +203,7 @@ pip install pytest
 pytest -q
 ```
 
-The suite covers 213 cases across two files — `tests/smoke_test.py` (happy-path and feature regressions) and `tests/edge_cases.py` (encoding, malformed input, infeasibility, custom platforms, rate-only campaigns, multi-component composition, Monte Carlo, all-platforms stress).
+The suite covers 213 cases across four files — `tests/smoke_test.py` (happy-path and feature regressions), `tests/test_edge_cases.py` (encoding, malformed input, infeasibility, custom platforms, rate-only campaigns, multi-component composition, Monte Carlo, all-platforms stress), `tests/test_accuracy.py` (hand-computable numeric checks), and `tests/test_bug_fixes.py` (named regression guards).
 
 The same command runs automatically on every push and pull request via GitHub Actions.
 
@@ -230,8 +230,11 @@ The same command runs automatically on every push and pull request via GitHub Ac
 │   └── module7.py               # Insights + Module7Policy
 ├── docs/                        # Design + modelling documentation
 ├── tests/
+│   ├── conftest.py              # Headless session-state fixture
 │   ├── smoke_test.py            # Happy-path + feature regressions
-│   ├── edge_cases.py            # Adversarial: encoding, malformed, infeasible
+│   ├── test_edge_cases.py       # Adversarial: encoding, malformed, infeasible
+│   ├── test_accuracy.py         # Hand-computable numeric checks
+│   ├── test_bug_fixes.py        # Named regression guards
 │   └── behavioural_check.py     # Realistic scenarios printed end-to-end
 ├── .github/workflows/tests.yml  # CI runs pytest on every push
 ├── LICENSE
@@ -246,10 +249,10 @@ The same command runs automatically on every push and pull request via GitHub Ac
 
 Detailed explanations of system behaviour and modelling choices are provided in the `docs/` directory:
 
-* **modules.md** – role and responsibility of each module
-* **scenarios.md** – scenario design and interpretation logic
-* **decision_logic.md** – optimisation assumptions and modelling rationale
-* **calibration.md** – every hand-set numeric constant in the engine, its source / intuition, what changes if the value moves, and whether a user-facing override exists
+* **MODULES.md** – role and responsibility of each module
+* **SCENARIOS.md** – scenario design and interpretation logic
+* **DECISION_LOGIC.md** – optimisation assumptions and modelling rationale
+* **CALIBRATION.md** – every hand-set numeric constant in the engine, its source / intuition, what changes if the value moves, and whether a user-facing override exists
 
 These documents expand on the architectural and decision principles outlined above.
 

--- a/app.py
+++ b/app.py
@@ -292,7 +292,7 @@ def build_forecast_df(
 ) -> pd.DataFrame:
     """Build the per-KPI forecast table.
 
-    Confidence bands surfaced by Module 6 (``predicted_kpi_low``,
+    Uncertainty bands surfaced by Module 6 (``predicted_kpi_low``,
     ``predicted_kpi_high``, ``band_pct``) are carried into the table so
     the report shows the ±range the engine knows, not just the central
     point estimate.
@@ -1249,7 +1249,7 @@ def module3_ui(state: WizardState) -> None:
                     step=1,
                     key=f"hist_days_{platform}",
                     help="How many days of past performance these numbers cover. "
-                         "Confidence bands shrink as the window grows (more data → less noise).",
+                         "Uncertainty bands shrink as the window grows (more data → less noise).",
                 )
             with col_budget:
                 budget = st.number_input(
@@ -1689,7 +1689,7 @@ def results_ui(state: WizardState) -> None:
                         st.dataframe(show_forecast, use_container_width=True, hide_index=True)
                         st.caption(
                             "Predicted KPI is the central forecast; low / high and ±% "
-                            "show the confidence band Module 6 derived from data "
+                            "show the uncertainty band Module 6 derived from data "
                             "(observation CV when available, otherwise scaled by the "
                             "historical window length). Allocated Budget shows the shared "
                             "(Platform, Objective) cell budget once per cell; sibling KPIs "
@@ -2075,7 +2075,7 @@ def module1_ui(state: WizardState) -> None:
             min_value=1,
             value=int(state.campaign_duration_days or 30),
             step=1,
-            help="Used to scale industry-effective minimums and historical-window confidence bands.",
+            help="Used to scale industry-effective minimums and historical-window uncertainty bands.",
         )
 
     # ── Goal values (utility weights) ──────────────────────────────────────

--- a/app.py
+++ b/app.py
@@ -2282,7 +2282,7 @@ def module2_ui(state: WizardState) -> None:
 
 
 def main() -> None:
-    st.set_page_config(page_title="Marketing Budget Optimisation", layout="wide")
+    st.set_page_config(page_title="CLARO — Marketing Budget Optimisation", layout="wide")
     initialise_state()
 
     state: WizardState = st.session_state["wizard_state"]

--- a/docs/CALIBRATION.md
+++ b/docs/CALIBRATION.md
@@ -226,7 +226,7 @@ warnings, not constraints. Each section flags which category a constant is in.
 - **Source:** Empirical Bayes in the textbook sense estimates the prior
   strength from the data; here it's fixed at 30 days because:
   1. The reference window matches the conventional "campaign month"
-     baseline used in Module 6's confidence bands.
+     baseline used in Module 6's uncertainty bands.
   2. The data needed for genuine empirical Bayes estimation
      (cross-platform variance of true productivities) isn't reliably
      available from typical Module 3 inputs.
@@ -258,12 +258,12 @@ warnings, not constraints. Each section flags which category a constant is in.
 
 ---
 
-## 5. Confidence bands on the forecast
+## 5. Uncertainty bands on the forecast
 
 ### `DEFAULT_UNCERTAINTY_BAND = 0.30`
 
 - **Location:** `modules/module6.py:22`
-- **Role:** ±30% fallback confidence band on count-KPI forecasts when
+- **Role:** ±30% fallback uncertainty band on count-KPI forecasts when
   no per-KPI history is available. Used when Module 3 has neither
   multi-period observations nor a `historical_days` field.
 - **Source:** Industry convention. Display ad performance week-to-week
@@ -291,7 +291,7 @@ warnings, not constraints. Each section flags which category a constant is in.
 ### Band clamps `_MIN_BAND = 0.05, _MAX_BAND = 1.00`
 
 - **Location:** `modules/module6.py:31–32`
-- **Role:** Hard limits on per-KPI confidence bands. Floor at 5%
+- **Role:** Hard limits on per-KPI uncertainty bands. Floor at 5%
   prevents pathological zero-variance inputs from producing zero
   bands (false precision); cap at 100% prevents bands from rendering
   forecasts meaningless ("plan delivers between 0 and 2× the point

--- a/modules/module3.py
+++ b/modules/module3.py
@@ -364,7 +364,7 @@ def finalise_module3_from_inputs(
                     continue
             validated_kpis[var] = v
 
-        # Optional multi-period observations for variance-based confidence
+        # Optional multi-period observations for variance-based uncertainty
         # bands in Module 6.  Shape: {var: [v1, v2, ...]}.  Only count KPIs are
         # supported (rate KPIs are already an average).  Each list must contain
         # positive finite values; invalid entries are dropped, and lists with

--- a/modules/module6.py
+++ b/modules/module6.py
@@ -15,7 +15,7 @@ _KPI_KIND: Dict[str, str] = {
     for row in KPI_CONFIG
 }
 
-# Default ±30% confidence band on count-KPI forecasts.  This is the *fallback*
+# Default ±30% uncertainty band on count-KPI forecasts.  This is the *fallback*
 # used when no per-KPI history is available; whenever Module 3 has either
 # multi-period observations or a historical_days length, the band is derived
 # from data (see _band_for_kpi).
@@ -86,8 +86,8 @@ class Module6ForecastRow:
     ratio_kpi_per_budget: float   # count KPI: units/£; rate KPI: the rate value itself
     allocated_budget: float
     predicted_kpi: float          # count KPI: units; rate KPI: expected rate (dimensionless)
-    predicted_kpi_low: float = 0.0    # lower bound of the confidence band
-    predicted_kpi_high: float = 0.0   # upper bound of the confidence band
+    predicted_kpi_low: float = 0.0    # lower bound of the uncertainty band
+    predicted_kpi_high: float = 0.0   # upper bound of the uncertainty band
     band_source: str = "default"      # "observations" | "window_scaled" | "default"
     band_pct: float = 0.0             # the band fraction actually used for this row
 
@@ -270,7 +270,7 @@ def compute_module6_forecast(
                     d.skipped_invalid_ratio_items += 1
                     continue
 
-                # Confidence band: count KPIs get a ±band% range to reflect the
+                # Uncertainty band: count KPIs get a ±band% range to reflect the
                 # inherent noise of digital ad performance.  Rate KPIs already
                 # bake in averaging across the historical window, so we keep
                 # the point estimate without a wider band.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pandas==2.2.1
 numpy==1.26.4
 matplotlib==3.8.3
 reportlab==4.1.0
-openpyxl
-pypdf
+openpyxl==3.1.5
+pypdf==6.12.2

--- a/test_datasets/06_accuracy_hand_computable/SCENARIO.md
+++ b/test_datasets/06_accuracy_hand_computable/SCENARIO.md
@@ -40,7 +40,7 @@ FB is 10× more productive than LI.
 ## What this stresses
 
 - Forecast formula correctness (count KPI)
-- Confidence-band default at the reference 30-day window
+- Uncertainty-band default at the reference 30-day window
 - Budget closure on a one-objective LP
 - The pipeline's ability to round-trip historical_count and
   historical_budget through M3 → M4 → M5 → M6 without distortion

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1506,7 +1506,7 @@ def test_module6_band_falls_back_to_default_without_module3_data() -> None:
     assert row.band_pct == pytest.approx(DEFAULT_UNCERTAINTY_BAND)
 
 
-def test_module6_count_kpi_has_confidence_band() -> None:
+def test_module6_count_kpi_has_uncertainty_band() -> None:
     """Module 6 must surface a ±band on every count-KPI forecast so the
     output cannot be mistaken for a precise commitment."""
     from modules.module6 import compute_module6_forecast, DEFAULT_UNCERTAINTY_BAND
@@ -1799,7 +1799,7 @@ def test_build_forecast_df_collapses_cell_budget_to_primary_row() -> None:
     expected_roas = (primary["Predicted KPI"] * 0.001) / primary["Allocated Budget"]
     assert primary["ROAS"] == pytest.approx(expected_roas, rel=1e-6)
 
-    # And the new confidence-band columns are present and well-formed.
+    # And the new uncertainty-band columns are present and well-formed.
     for _, row in fb_aw_rows.iterrows():
         assert row["Predicted KPI (low)"] <= row["Predicted KPI"] <= row["Predicted KPI (high)"]
         assert row["Band ±%"] >= 0.0

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -8,7 +8,7 @@ output matches the hand-computed value to a tight tolerance.
 
 Categories:
   ACC-F: Forecast accuracy        (Module 6: predicted_kpi = spend × ratio)
-  ACC-B: Confidence band accuracy (Module 6: ±band% on count KPIs)
+  ACC-B: Uncertainty band accuracy (Module 6: ±band% on count KPIs)
   ACC-C: Constraint accuracy      (Module 5: budget closure, floors honoured)
   ACC-S: Scenario accuracy        (Module 5: scenario budget = multiplier × total)
   ACC-P: Plan B accuracy          (Module 7: cap binds exactly, trade-off correct)
@@ -208,7 +208,7 @@ def test_ACC_F_04_zero_allocation_produces_zero_forecast():
 
 
 # ═════════════════════════════════════════════════════════════════════════
-# ACC-B: Confidence band accuracy
+# ACC-B: Uncertainty band accuracy
 # Formula: band = 0.30 × sqrt(30 / historical_days), clamped to [0.05, 1.00]
 # ═════════════════════════════════════════════════════════════════════════
 
@@ -706,7 +706,7 @@ def test_ACC_F_06_summed_forecast_matches_per_platform_arithmetic():
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# ACC-B-04 / 05 / 06: extended confidence-band accuracy
+# ACC-B-04 / 05 / 06: extended uncertainty-band accuracy
 # ─────────────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Prepares the repository for the `v0.2.0` tag and DOI. Three commits, all
non-behavioural (metadata, docs, and user-facing wording). Full test
suite passes: **213/213**.

## Commits

1. **Rename project to CLARO for publication** — sets the citable name
   to *"CLARO: Constrained Linear Allocation and Resource Optimiser — a
   Decision-Support Framework for Marketing Budget Allocation"* in
   `CITATION.cff` (title), `README.md` (heading + citation example), and
   the Streamlit page title. CFF validated against schema 1.2.0.

2. **Fix stale docs references and pin remaining deps** — README test
   description corrected (213 cases across 4 files; `test_edge_cases.py`),
   project-structure tree refreshed (`conftest.py`, `test_accuracy.py`,
   `test_bug_fixes.py`), docs filenames matched to actual casing, bare
   `.wiki.git` clone URL replaced with the browsable wiki link, and
   `openpyxl` / `pypdf` pinned for a reproducible artifact.

3. **Disambiguate forecast "uncertainty band" from decision "confidence
   score"** — the results page and report carried two distinct concepts
   both labelled "confidence" (Module 7's decision confidence score vs.
   Module 6's per-KPI forecast band). The word "confidence" is now
   reserved for the score; the forecast range is "uncertainty band"
   everywhere user-facing, plus supporting docstrings, comments, docs,
   and test labels. Internal identifiers were already `uncertainty_band`
   / `DEFAULT_UNCERTAINTY_BAND`, so this is wording-only with no
   behavioural effect.

## Verification

- `import app` OK
- `pytest -q` → **213 passed**
- `cffconvert --validate` → valid (CFF 1.2.0)
- No `confidence band` references remain; the only "confidence" tokens
  left are the legitimate `confidence_score` machinery in `module7.py`.

After merge: tag `v0.2.0` on `main` (ensure the repo is enabled on
zenodo.org first) to mint the DOI.

https://claude.ai/code/session_01TCYigPquGovN5hrhDpaezZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCYigPquGovN5hrhDpaezZ)_