### PR TITLE
Align app with paper: remove dead Exploration mode, add scenario-drop test

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ pip install pytest
 pytest -q
 ```
 
-The suite covers 213 cases across four files — `tests/smoke_test.py` (happy-path and feature regressions), `tests/test_edge_cases.py` (encoding, malformed input, infeasibility, custom platforms, rate-only campaigns, multi-component composition, Monte Carlo, all-platforms stress), `tests/test_accuracy.py` (hand-computable numeric checks), and `tests/test_bug_fixes.py` (named regression guards).
+The suite covers 214 cases across four files — `tests/smoke_test.py` (happy-path and feature regressions), `tests/test_edge_cases.py` (encoding, malformed input, infeasibility, custom platforms, rate-only campaigns, multi-component composition, Monte Carlo, all-platforms stress), `tests/test_accuracy.py` (hand-computable numeric checks), and `tests/test_bug_fixes.py` (named regression guards).
 
 The same command runs automatically on every push and pull request via GitHub Actions.
 

--- a/app.py
+++ b/app.py
@@ -1728,13 +1728,13 @@ def results_ui(state: WizardState) -> None:
     # SECTION 5 — ADVANCED CONTROLS (refine, diagnostics, robustness)
     # ═══════════════════════════════════════════════════════════════════════
     with st.expander("Decision mode and refine policy", expanded=False):
+        _mode_options = ["Performance first", "Risk managed"]
         st.selectbox(
             "Decision mode",
-            options=["Performance first", "Risk managed", "Exploration"],
-            index=["Performance first", "Risk managed", "Exploration"].index(decision_mode),
+            options=_mode_options,
+            index=_mode_options.index(decision_mode) if decision_mode in _mode_options else 0,
             key="_decision_mode",
-            help="Performance first chooses the LP optimum. Risk managed always offers Plan B. "
-                 "Exploration loosens scenario coupling.",
+            help="Performance first chooses the LP optimum. Risk managed always offers Plan B.",
         )
  
         st.caption(

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1687,3 +1687,47 @@ def test_lg_split_purchases_parses_independently():
         f"swallowed by Leads fallthrough; got "
         f"{result['kpis'].get('FB_LG_PURCHASES')}"
     )
+
+
+def test_conservative_scenario_dropped_when_floor_exceeds_cap():
+    """A per-platform floor that fits the base cap but exceeds the (smaller)
+    conservative cap must cause the conservative scenario to be dropped, while
+    base and optimistic survive.
+
+    Guards the ``continue`` branch in ``run_module5_lp_scenarios`` that the
+    paper's "evaluates each allocation across up to three scenarios" claim
+    relies on. The discriminating check is built in: with a feasible floor all
+    three scenarios survive, so a pass here means the drop is caused by
+    infeasibility, not by an unconditional bug.
+    """
+    def survived(fb_floor):
+        s = WizardState()
+        complete_module1_and_advance(
+            s, raw_objectives=["lg"], raw_budget=10_000.0, raw_duration_days=30,
+        )
+        run_module2(s, selected_platforms=["fb", "li"], priorities_input={
+            "fb": {"priority_1": "lg", "priority_2": None},
+            "li": {"priority_1": "lg", "priority_2": None},
+        })
+        s.min_spend_per_platform = {"fb": fb_floor, "li": 0.0}
+        s.scenario_multipliers = {"conservative": 0.85, "base": 1.0, "optimistic": 1.15}
+        finalise_module3_from_inputs(s, platform_inputs={
+            "fb": {"budget": 1_000.0, "historical_days": 30, "kpis": {"FB_LG_LEADS": 100.0}},
+            "li": {"budget": 1_000.0, "historical_days": 30, "kpis": {"LI_LG_LEADS": 10.0}},
+        })
+        run_module4(s)
+        run_module5(s)
+        return set(s.module5_scenario_bundle.results_by_scenario.keys())
+
+    # £8,000 fits the conservative cap (£10,000 x 0.85 = £8,500): all three survive.
+    assert survived(8_000.0) == {"conservative", "base", "optimistic"}, (
+        "feasible floor should leave every scenario intact"
+    )
+    # £9,000 exceeds the conservative cap: conservative drops, the rest survive.
+    infeasible = survived(9_000.0)
+    assert "conservative" not in infeasible, (
+        "conservative must be dropped when its floor exceeds its budget cap"
+    )
+    assert {"base", "optimistic"} <= infeasible, (
+        "feasible scenarios must still be reported when another is dropped"
+    )


### PR DESCRIPTION
Three small, low-risk changes from a paper/code consistency audit of the CLARO SoftwareX submission.

## Changes

1. **Remove non-functional "Exploration" decision mode from the UI** (`app.py`).
   The `"Exploration"` option in the decision-mode selector routed through the same path as `"Performance first"` (`run_module7` branches only on `"risk managed"`), so its "loosens scenario coupling" help text described behaviour that was never implemented. Removing it makes the UI match the interpretation layer's two real modes and aligns the app with the paper, which now describes two decision modes. The index lookup is guarded so a stale saved selection cannot raise.

2. **Add a regression test for the infeasible-floor scenario drop** (`tests/test_edge_cases.py`).
   `run_module5_lp_scenarios` silently drops a scenario whose policy floors exceed its (scenario-scaled) budget cap. The existing single-scenario test fabricated the reduced bundle directly rather than triggering this branch, and the accuracy tests skip themselves when a scenario is absent — so the drop condition itself was untested. The new test is self-discriminating: all three scenarios survive on a feasible floor; only conservative drops on an infeasible one. This guards the paper's "evaluates each allocation across up to three scenarios" claim.

3. **Bump the README test count to 214** to reflect the added test.

## Verification

- Full suite green: **214 passed**.
- No `Exploration` references remain anywhere in the codebase; `app.py` parses cleanly.
- The new test discriminates (feasible floor → all three scenarios survive; infeasible → only conservative drops), so it cannot pass vacuously.

https://claude.ai/code/session_014fcPXcwPMhHKTQVHe8qcAv

---
_Generated by [Claude Code](https://claude.ai/code/session_014fcPXcwPMhHKTQVHe8qcAv)_